### PR TITLE
Fix a command in INSTALLATION.md

### DIFF
--- a/INSTALLATION.md
+++ b/INSTALLATION.md
@@ -25,7 +25,7 @@ Log in and run the following query:
 
 ```graphql
 query GetCategory {
-  github_repository(name: "your-repository-name", owner: "your-org") {
+  repository(name: "your-repository-name", owner: "your-org") {
     discussionCategory(slug: "preview-comments") {
       id
     }


### PR DESCRIPTION
`github_repository` is deprecated by `repository`.